### PR TITLE
Simplify regex for N to N relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ Now write a map function like this:
 function(doc) {
   if (!doc._id.match(/^friendship:/)) return
   
-  var ids = doc._id.match(/person:([^:]*)/g)
+  var ids = doc._id.match(/person:[^:]*/g)
   var one = ids[0]
   var two = ids[1]
 


### PR DESCRIPTION
This had me confused for a while. I was thinking the parenthesis were used to capture just the name. Turns out it's the entire "person:{name}" that's being used. I was thinking it was just "{name}" because of the parenthesis. It makes so much more sense now that I know it's not though.